### PR TITLE
Updated settings to allow HTML browsable API

### DIFF
--- a/cognoma_site/settings.py
+++ b/cognoma_site/settings.py
@@ -31,14 +31,23 @@ ALLOWED_HOSTS = [os.getenv('DJANGO_HOST', '*')]
 
 # Application definition
 
-INSTALLED_APPS = [
+DJANGO_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.postgres',
+    'django.contrib.staticfiles',
+]
+
+THIRD_PARTY_APPS = [
     'rest_framework',
+]
+
+LOCAL_APPS = [
     'api.apps.ApiConfig',
     'organisms',
     'genes',
 ]
+
+INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 REST_FRAMEWORK = {
     'UNAUTHENTICATED_USER': None,
@@ -46,7 +55,13 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 100,
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'api.auth.CognomaAuthentication',
-    )
+    ),
+    'DEFAULT_RENDERER_CLASSES': (
+        # JSON as primary renderer for API functionality
+        'rest_framework.renderers.JSONRenderer',
+        # Support HTML / web browsable renderer for interacting with API
+        'rest_framework.renderers.BrowsableAPIRenderer',
+    ),
 }
 
 MIDDLEWARE_CLASSES = [
@@ -97,3 +112,13 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.9/howto/static-files/
+
+STATIC_URL = '/static/'
+
+# Extra static assets that aren't tied to an app
+STATICFILES_DIRS = [
+]


### PR DESCRIPTION
### Motivation

Use Django REST Framework default HTML / web browsable API in response to issue #41 

### API changes

None

### Implementation Notes

- Split up the definition of the Django apps so as to clarify where the apps are coming from
- Use of `django.contrib.staticfiles` requires setting the `STATIC_URL` which, for now, has been set to a rather unimaginative value of `/static/`

### Functional Tests

Tests passing locally:

```
./manage.py test -v2 -k
Using existing test database for alias 'default' ('test_cognoma_core_service')...
Operations to perform:
  Synchronize unmigrated apps: organisms, rest_framework, postgres, genes, staticfiles
  Apply all migrations: api, contenttypes
Synchronizing apps without migrations:
  Creating tables...
    Running deferred SQL...
Running migrations:
  No migrations to apply.
test_cannot_update_other_user_classifier (api.test.test_classifiers.ClassifierTests) ... ok
test_create_classifier (api.test.test_classifiers.ClassifierTests) ... ok
test_create_from_internal_service (api.test.test_classifiers.ClassifierTests) ... ok
test_expansion (api.test.test_classifiers.ClassifierTests) ... ok
test_get_classifier (api.test.test_classifiers.ClassifierTests) ... ok
test_list_classifiers (api.test.test_classifiers.ClassifierTests) ... ok
test_must_be_logged_in (api.test.test_classifiers.ClassifierTests) ... ok
test_update_classifier (api.test.test_classifiers.ClassifierTests) ... ok
test_update_from_internal_service (api.test.test_classifiers.ClassifierTests) ... ok
test_get_disease (api.test.test_diseases.DiseaseTests) ... ok
test_list_diseases (api.test.test_diseases.DiseaseTests) ... ok
test_entrezid_filter (api.test.test_genes.GeneTests) ... ok
test_get_gene (api.test.test_genes.GeneTests) ... ok
test_list_genes (api.test.test_genes.GeneTests) ... ok
test_get_mutations (api.test.test_mutations.MutationTests) ... ok
test_list_mutations (api.test.test_mutations.MutationTests) ... ok
test_get_sample (api.test.test_sample.SampleTests) ... ok
test_list_samples (api.test.test_sample.SampleTests) ... ok
test_cannot_update_other_user (api.test.test_users.UserTests) ... ok
test_create_user (api.test.test_users.UserTests) ... ok
test_get_user (api.test.test_users.UserTests) ... ok
test_get_user_self (api.test.test_users.UserTests) ... ok
test_list_users (api.test.test_users.UserTests) ... ok
test_update_user (api.test.test_users.UserTests) ... ok
test_user_update_must_be_logged_in (api.test.test_users.UserTests) ... ok

----------------------------------------------------------------------
Ran 25 tests in 0.413s

OK
Preserving test database for alias 'default' ('test_cognoma_core_service')...
```

### Screenshots/Logs

![samples](https://cloud.githubusercontent.com/assets/1820761/22045859/f752d60c-dcea-11e6-92d6-eae2e733fcfb.png)

