### PR TITLE
Stop using Django development server in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,32 @@
 FROM python:3.5.1
+
+MAINTAINER "Project Cognoma"
+
+# System packages
+RUN apt-key update && apt-get update
+# Supervisor for running application in production
+RUN apt-get install supervisor -y
+# Clean up package manager
+RUN apt-get autoremove -y
+RUN rm -rvf /var/cache/apt
+
+
+# Environment variables
 ENV PYTHONUNBUFFERED 1
+
+
+# Directories
 RUN mkdir /code
 WORKDIR /code
-ADD . /code/
+
+
+# Python environment
+COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
+
+
+# Mount application code
+ADD . /code/
+
+# Default entrypoint
+ENTRYPOINT "/code/scripts/run_prod.sh"

--- a/config/prod/gunicorn.conf
+++ b/config/prod/gunicorn.conf
@@ -2,7 +2,7 @@
 # http://docs.gunicorn.org/en/stable/settings.html
 
 # Address
-bind = '127.0.0.1:8000'
+bind = '0.0.0.0:8000'
 
 # Worker configuration
 # http://docs.gunicorn.org/en/stable/design.html#async-workers
@@ -10,7 +10,7 @@ worker_class = 'eventlet'
 
 # Rule of thumb for workers is (2 * ncpus) + 1
 # http://docs.gunicorn.org/en/stable/design.html#how-many-workers
-workers = 3
+workers = 2
 threads = 8
 worker_connections = 10
 

--- a/config/prod/gunicorn.conf
+++ b/config/prod/gunicorn.conf
@@ -1,0 +1,29 @@
+# For full details, see:
+# http://docs.gunicorn.org/en/stable/settings.html
+
+# Address
+bind = '127.0.0.1:8000'
+
+# Worker configuration
+# http://docs.gunicorn.org/en/stable/design.html#async-workers
+worker_class = 'eventlet'
+
+# Rule of thumb for workers is (2 * ncpus) + 1
+# http://docs.gunicorn.org/en/stable/design.html#how-many-workers
+workers = 3
+threads = 8
+worker_connections = 10
+
+# Restart of worker after certain number of requests to avoid memory leaks
+max_requests = 1000
+max_requests_jitter = 100
+
+# Timeout settings
+graceful_timeout = 300
+timeout = 300
+
+# Logging
+loglevel = 'info'
+
+# Daemonization
+daemon = False

--- a/config/prod/supervisord.conf
+++ b/config/prod/supervisord.conf
@@ -1,0 +1,19 @@
+[supervisord]
+; Don't want supervisord to be daemonised, as otherwise when running under
+; Docker it will assume that the command has completed, whereas we want
+; supervisord to stay up as long as the application is running
+nodaemon=true
+
+
+[program:core_service]
+command=/usr/local/bin/gunicorn cognoma_site.wsgi:application -c /code/config/prod/gunicorn.conf
+directory=/code
+; User account with minimal privileges
+user=nobody
+numprocs=1
+autostart=true
+autorestart=true
+; Redirect all logging to Docker stdout
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres
   core:
     build: .
-    command: bash -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    entrypoint: ./scripts/run_dev.sh
     volumes:
       - .:/code
     ports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,11 @@ django-organisms==0.3
 djangorestframework==3.4.0
 djangorestframework-expander==0.2.1
 drf-dynamic-fields==0.1.1
+enum-compat==0.0.2
+eventlet==0.20.1
+gevent==1.2.1
+greenlet==0.4.11
+gunicorn==19.6.0
 idna==2.1
 psycopg2==2.6.2
 pyasn1==0.1.9

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -x
+
+python manage.py migrate -v3 --no-input
+python manage.py runserver 0.0.0.0:8000

--- a/scripts/run_prod.sh
+++ b/scripts/run_prod.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -x
+
+# Application is configured to run under Supervisord, which in turn monitors
+# the Gunicorn web server
+supervisord -c /code/config/prod/supervisord.conf


### PR DESCRIPTION
### Motivation

Move away from using the Django development server in production as it's not suitable, see issue #39 

### API changes

None

### Implementation Notes

- Reordered Dockerfile to make slower changing steps appear higher up, e.g. system-level packages and python (virtual) environment packages
- Use of Supervisord to monitor web server process
- Use Gunicorn as the production WSGI
- Added in convenience scripts for running in dev/prod setup

### Functional Tests

Not been able to verify that this runs locally, see issue #47

### Screenshots/Logs

Will be updated once #47 has been resolved.