### PR TITLE
Remove django genes

### DIFF
--- a/api/migrations/0001_initial.py
+++ b/api/migrations/0001_initial.py
@@ -85,4 +85,9 @@ class Migration(migrations.Migration):
             name='diseases',
             field=models.ManyToManyField(to='api.Disease'),
         ),
+        migrations.AddField(
+            model_name='classifier',
+            name='user',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='api.User'),
+        ),
     ]

--- a/api/migrations/0001_initial.py
+++ b/api/migrations/0001_initial.py
@@ -13,7 +13,6 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('genes', '__latest__'),
     ]
 
     operations = [
@@ -45,7 +44,6 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('status', models.BooleanField()),
-                ('gene', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='genes.Gene')),
             ],
             options={
                 'db_table': 'mutations',
@@ -86,15 +84,5 @@ class Migration(migrations.Migration):
             model_name='classifier',
             name='diseases',
             field=models.ManyToManyField(to='api.Disease'),
-        ),
-        migrations.AddField(
-            model_name='classifier',
-            name='genes',
-            field=models.ManyToManyField(to='genes.Gene'),
-        ),
-        migrations.AddField(
-            model_name='classifier',
-            name='user',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='api.User'),
         ),
     ]

--- a/api/migrations/0003_genes_mutations.py
+++ b/api/migrations/0003_genes_mutations.py
@@ -33,12 +33,12 @@ class Migration(migrations.Migration):
             model_name='mutation',
             name='status',
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name='classifier',
             name='genes',
             field=models.ManyToManyField(to='api.Gene'),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name='mutation',
             name='gene',
             field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='mutations', to='api.Gene'),

--- a/cognoma_site/settings.py
+++ b/cognoma_site/settings.py
@@ -43,8 +43,6 @@ THIRD_PARTY_APPS = [
 
 LOCAL_APPS = [
     'api.apps.ApiConfig',
-    'organisms',
-    'genes',
 ]
 
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,6 @@ cryptography==1.5.2
 Django==1.9.8
 django-filter==0.14.0
 django-fixtureless==1.4.3.3
-django-genes==0.3
-django-haystack==2.5.0
-django-organisms==0.3
 djangorestframework==3.4.0
 djangorestframework-expander==0.2.1
 drf-dynamic-fields==0.1.1


### PR DESCRIPTION
### Motivation

We are including django-genes as a dependency in the app, even though it is no longer used. We would like to remove it and no longer require it.

Fixes https://github.com/cognoma/core-service/issues/47

### Implementation Notes

I edited the migrations directly, but this should not affect existing instances of the cognoma app schema. It should also reflect the same schema for new builds.

### Functional Tests

Running migrations and bringing the app online. Running tests.