### PR TITLE
Adding batch_size param to loaddata

### DIFF
--- a/api/management/commands/loaddata.py
+++ b/api/management/commands/loaddata.py
@@ -92,4 +92,4 @@ class Command(BaseCommand):
                             #except:
                             #    print('Had an issue inserting sample', sample_id, 'mutation', entrez_gene_id)
                 print('Bulk loading mutation data...')
-                Mutation.objects.bulk_create(mutation_list)
+                Mutation.objects.bulk_create(mutation_list, batch_size=1000)


### PR DESCRIPTION
### Motivation

The initial `python manage.py loaddata` command would fail with a database timeout. The query dumped to the docker console looked truncated. We found that adding the `batch_size` parameter solved this issue.

### Implementation Notes

collaboration with @cgreene