### PR TITLE
User slug list endpoint

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -4,16 +4,17 @@ import random
 from rest_framework import serializers, exceptions
 from expander import ExpanderSerializerMixin
 from drf_dynamic_fields import DynamicFieldsMixin
-
+from django.contrib.postgres import fields as postgresfields
 from api.models import User, Classifier, Disease, Sample, Mutation, Gene
 
 
 class UserSerializer(DynamicFieldsMixin, serializers.Serializer):
-    id = serializers.IntegerField(read_only=True)
-    name = serializers.CharField(required=False, allow_blank=True, max_length=255)
-    email = serializers.CharField(required=False, allow_blank=False, max_length=255)
-    created_at = serializers.DateTimeField(read_only=True, format='iso-8601')
-    updated_at = serializers.DateTimeField(read_only=True, format='iso-8601')
+    id           = serializers.IntegerField(read_only=True)
+    name         = serializers.CharField(required=False, allow_blank=True, max_length=255)
+    email        = serializers.CharField(required=False, allow_blank=False, max_length=255)
+    created_at   = serializers.DateTimeField(read_only=True, format='iso-8601')
+    updated_at   = serializers.DateTimeField(read_only=True, format='iso-8601')
+    random_slugs = postgresfields.ArrayField(serializers.CharField(max_length=25))
 
     def create(self, validated_data):
         ## 25 charcters to get 128bit unique random slug
@@ -45,7 +46,7 @@ class UserSerializer(DynamicFieldsMixin, serializers.Serializer):
            del output['email']
 
         ## Only return secure random slug on create
-        if self.context['request'].method == 'POST':
+        if (auth_type == 'Bearer' and self.context['request'].method == 'GET' ):
             output['random_slugs'] = obj.random_slugs
 
         return output

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -45,7 +45,7 @@ class UserSerializer(DynamicFieldsMixin, serializers.Serializer):
               self.context['request'].user.id != obj.id))):
            del output['email']
 
-        ## Only return secure random slug on create
+        ## Only return secure random slug on authenticated GET requests
         if (auth_type == 'Bearer' and self.context['request'].method == 'GET' ):
             output['random_slugs'] = obj.random_slugs
 

--- a/api/views.py
+++ b/api/views.py
@@ -55,6 +55,14 @@ class UserListCreate(generics.ListCreateAPIView):
     ordering_fields = ('created_at', 'updated_at')
     ordering = ('created_at',)
 
+class UserSlugListCreate(generics.ListCreateAPIView):
+    def get_queryset(self):
+        random_slug = self.kwargs['random_slug']
+        return User.objects.filter(random_slugs__contains='{'+random_slug+'}')
+
+    permission_classes = (UserUpdateSelfOnly,)
+    serializer_class   = serializers.UserSerializer
+
 class UserRetrieveUpdate(generics.RetrieveUpdateAPIView):
     permission_classes = (UserUpdateSelfOnly,)
     queryset = User.objects.all()

--- a/cognoma_site/urls.py
+++ b/cognoma_site/urls.py
@@ -5,14 +5,21 @@ from api import views
 urlpatterns = [
     url(r'^classifiers/?$', views.ClassifierListCreate.as_view()),
     url(r'^classifiers/(?P<id>[0-9]+)$', views.ClassifierRetrieveUpdate.as_view()),
+
     url(r'^users/?$', views.UserListCreate.as_view()),
     url(r'^users/(?P<id>[0-9]+)$', views.UserRetrieveUpdate.as_view()),
+    url(r'^users/(?P<random_slug>.+)$', views.UserSlugListCreate.as_view()),
+    
+
     url(r'^genes/?$', views.GeneList.as_view()),
     url(r'^genes/(?P<entrez_gene_id>[0-9]+)$', views.GeneRetrieve.as_view()),
+
     url(r'^diseases/?$', views.DiseaseList.as_view()),
     url(r'^diseases/(?P<acronym>[a-zA-Z]+)$', views.DiseaseRetrieve.as_view()),
+
     url(r'^mutations/?$', views.MutationList.as_view()),
     url(r'^mutations/(?P<id>[0-9]+)$', views.MutationRetrieve.as_view()),
+
     url(r'^samples/?$', views.SampleList.as_view()),
     url(r'^samples/(?P<sample_id>[A-Z0-9\-]+)$', views.SampleRetrieve.as_view()),
 ]


### PR DESCRIPTION
### Motivation
This PR is an attempt to resolve #58 for use in the user creation/login flow for the front-end. It allows you to query a single user given their random_slug value. This random_slug value is only obtained by the user in the front-end workflow upon the initial creation of their account, thus the possession of this value serves as a loose form of authentication. 

### API changes
Adds `/users/<random_slug>` endpoint, docs have not yet been updated to reflect this as this PR should be improved upon by a member of the core-service/backend team before merging into production. 


### Implementation Notes

This endpoint could potentially benefit from the use of JWT to insure that the GET request is  originating from the Cognoma front-end and not a bot or outside entity. 

