### PR TITLE
Separate id and slug user endpoints, fix slug retreival, update nginx CORS

### DIFF
--- a/api/test/test_users.py
+++ b/api/test/test_users.py
@@ -30,57 +30,13 @@ class UserTests(APITestCase):
 
         client.credentials(HTTP_AUTHORIZATION=token)
 
-        update_response = client.put('/users/id/' + str(create_response.data['id']),
+        update_response = client.put('/users/' + str(create_response.data['random_slugs'][0]),
                                      {'email': 'foo@yahoo.com'},
                                      format='json')
 
         self.assertEqual(update_response.status_code, 200)
         self.assertEqual(update_response.data['email'], 'foo@yahoo.com')
         self.assertEqual(list(update_response.data.keys()), self.user_keys)
-
-    def test_user_update_must_be_logged_in(self):
-        client = APIClient()
-
-        create_repsonse = client.post('/users', {}, format='json')
-
-        update_response = client.put('/users/id/' + str(create_repsonse.data['id']),
-                                     {'email': 'foo@yahoo.com'},
-                                     format='json')
-
-        self.assertEqual(update_response.status_code, 401)
-
-    def test_cannot_update_other_user(self):
-        client = APIClient()
-
-        user1_repsonse = client.post('/users', {}, format='json')
-        user2_response = client.post('/users', {}, format='json')
-
-        user2_token = 'Bearer ' + user2_response.data['random_slugs'][0]
-
-        client.credentials(HTTP_AUTHORIZATION=user2_token)
-
-        update_response = client.put('/users/id/' + str(user1_repsonse.data['id']),
-                                     {'email': 'foo@yahoo.com'},
-                                     format='json')
-
-        self.assertEqual(update_response.status_code, 403)
-
-    # def test_update_from_internal_service(self):
-    #     client = APIClient()
-
-    #     create_response = client.post('/users', {}, format='json')
-
-    #     self.assertEqual(create_response.status_code, 201)
-
-    #     client.credentials(HTTP_AUTHORIZATION=self.service_token)
-
-    #     update_response = client.put('/users/' + str(create_response.data['id']),
-    #                                  {'email': 'foo@yahoo.com'},
-    #                                  format='json')
-
-    #     self.assertEqual(update_response.status_code, 200)
-    #     self.assertEqual(update_response.data['email'], 'foo@yahoo.com')
-    #     self.assertEqual(list(update_response.data.keys()), self.user_update_get_self_keys)
 
     def test_list_users(self):
         client = APIClient()
@@ -99,11 +55,7 @@ class UserTests(APITestCase):
 
         self.assertEqual(user_create_response.status_code, 201)
 
-        user_id_response = client.get('/users/id/' + str(user_create_response.data['id']))
-
-        self.assertEqual(user_id_response.status_code, 401)
-
-        user_slug_response = client.get('/users/slug/' + str(user_create_response.data['random_slugs'][0]))
+        user_slug_response = client.get('/users/' + str(user_create_response.data['random_slugs'][0]))
 
         self.assertEqual(user_slug_response.status_code, 200)
         self.assertEqual(list(user_slug_response.data.keys()), self.user_keys)
@@ -119,12 +71,12 @@ class UserTests(APITestCase):
 
         client.credentials(HTTP_AUTHORIZATION=token)
 
-        user_id_response = client.get('/users/id/' + str(user_create_response.data['id']))
+        user_id_response = client.get('/users/' + str(user_create_response.data['random_slugs'][0]))
 
         self.assertEqual(user_id_response.status_code, 200)
         self.assertEqual(list(user_id_response.data.keys()), self.user_keys)
 
-        user_slug_response = client.get('/users/slug/' + str(user_create_response.data['random_slugs'][0]))
+        user_slug_response = client.get('/users/' + str(user_create_response.data['random_slugs'][0]))
 
         self.assertEqual(user_slug_response.status_code, 200)
         self.assertEqual(list(user_slug_response.data.keys()), self.user_keys)

--- a/api/test/test_users.py
+++ b/api/test/test_users.py
@@ -30,7 +30,7 @@ class UserTests(APITestCase):
 
         client.credentials(HTTP_AUTHORIZATION=token)
 
-        update_response = client.put('/users/' + str(create_response.data['id']),
+        update_response = client.put('/users/id/' + str(create_response.data['id']),
                                      {'email': 'foo@yahoo.com'},
                                      format='json')
 
@@ -43,7 +43,7 @@ class UserTests(APITestCase):
 
         create_repsonse = client.post('/users', {}, format='json')
 
-        update_response = client.put('/users/' + str(create_repsonse.data['id']),
+        update_response = client.put('/users/id/' + str(create_repsonse.data['id']),
                                      {'email': 'foo@yahoo.com'},
                                      format='json')
 
@@ -59,7 +59,7 @@ class UserTests(APITestCase):
 
         client.credentials(HTTP_AUTHORIZATION=user2_token)
 
-        update_response = client.put('/users/' + str(user1_repsonse.data['id']),
+        update_response = client.put('/users/id/' + str(user1_repsonse.data['id']),
                                      {'email': 'foo@yahoo.com'},
                                      format='json')
 
@@ -99,11 +99,11 @@ class UserTests(APITestCase):
 
         self.assertEqual(user_create_response.status_code, 201)
 
-        user_id_response = client.get('/users/' + str(user_create_response.data['id']))
+        user_id_response = client.get('/users/id/' + str(user_create_response.data['id']))
 
         self.assertEqual(user_id_response.status_code, 401)
 
-        user_slug_response = client.get('/users/' + str(user_create_response.data['random_slugs'][0]))
+        user_slug_response = client.get('/users/slug/' + str(user_create_response.data['random_slugs'][0]))
 
         self.assertEqual(user_slug_response.status_code, 200)
         self.assertEqual(list(user_slug_response.data.keys()), self.user_keys)
@@ -119,12 +119,12 @@ class UserTests(APITestCase):
 
         client.credentials(HTTP_AUTHORIZATION=token)
 
-        user_id_response = client.get('/users/' + str(user_create_response.data['id']))
+        user_id_response = client.get('/users/id/' + str(user_create_response.data['id']))
 
         self.assertEqual(user_id_response.status_code, 200)
         self.assertEqual(list(user_id_response.data.keys()), self.user_keys)
 
-        user_slug_response = client.get('/users/' + str(user_create_response.data['random_slugs'][0]))
+        user_slug_response = client.get('/users/slug/' + str(user_create_response.data['random_slugs'][0]))
 
         self.assertEqual(user_slug_response.status_code, 200)
         self.assertEqual(list(user_slug_response.data.keys()), self.user_keys)

--- a/api/views.py
+++ b/api/views.py
@@ -178,7 +178,10 @@ class UserRetrieveFromSlug(generics.RetrieveAPIView):
 
     def get_object(self):
         random_slug = self.kwargs['random_slug']
-        return self.queryset.get(random_slugs__contains=[random_slug])
+        try:
+            return self.queryset.get(random_slugs__contains=[random_slug])
+        except User.DoesNotExist:
+            raise NotFound("No user exists with random slug of {slug}.".format(slug=random_slug))
 
 # Genes
 

--- a/api/views.py
+++ b/api/views.py
@@ -164,13 +164,7 @@ class UserCreate(generics.CreateAPIView):
     permission_classes = []
     serializer_class = UserSerializer
 
-class UserRetrieveUpdate(generics.RetrieveUpdateAPIView):
-    permission_classes = (UserAccessSelfOnly,)
-    queryset = User.objects.all()
-    serializer_class = UserSerializer
-    lookup_field = 'id'
-
-class UserRetrieveFromSlug(generics.RetrieveAPIView):
+class UserRetrieveUpdateFromSlug(generics.RetrieveUpdateAPIView):
     permission_classes = []
     queryset = User.objects.all()
     serializer_class = UserSerializer

--- a/cognoma_site/urls.py
+++ b/cognoma_site/urls.py
@@ -17,8 +17,8 @@ urlpatterns = [
     url(r'^classifiers/(?P<id>[0-9]+)/fail/?$', views.FailClassifierTask.as_view()),
 
     url(r'^users/?$', views.UserCreate.as_view()),
-    url(r'^users/(?P<id>[0-9]+)$', views.UserRetrieveUpdate.as_view()),
-    url(r'^users/(?P<random_slug>.+)$', views.UserRetrieveFromSlug.as_view()),
+    url(r'^users/id/(?P<id>[0-9]+)/?$', views.UserRetrieveUpdate.as_view()),
+    url(r'^users/slug/(?P<random_slug>.+)$', views.UserRetrieveFromSlug.as_view()),
 
     # url(r'^genes/?$', views.GeneList.as_view()),
     # url(r'^genes/(?P<entrez_gene_id>[0-9]+)$', views.GeneRetrieve.as_view()),

--- a/cognoma_site/urls.py
+++ b/cognoma_site/urls.py
@@ -17,8 +17,7 @@ urlpatterns = [
     url(r'^classifiers/(?P<id>[0-9]+)/fail/?$', views.FailClassifierTask.as_view()),
 
     url(r'^users/?$', views.UserCreate.as_view()),
-    url(r'^users/id/(?P<id>[0-9]+)/?$', views.UserRetrieveUpdate.as_view()),
-    url(r'^users/slug/(?P<random_slug>.+)$', views.UserRetrieveFromSlug.as_view()),
+    url(r'^users/(?P<random_slug>.+)$', views.UserRetrieveUpdateFromSlug.as_view()),
 
     # url(r'^genes/?$', views.GeneList.as_view()),
     # url(r'^genes/(?P<entrez_gene_id>[0-9]+)$', views.GeneRetrieve.as_view()),

--- a/config/dev/nginx.conf
+++ b/config/dev/nginx.conf
@@ -36,6 +36,12 @@ server {
             add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
         }
 
+        if ($request_method = 'PUT') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
+        }
+
         if ($request_method = 'GET') {
             add_header 'Access-Control-Allow-Origin' '*';
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS';

--- a/config/prod/nginx.conf
+++ b/config/prod/nginx.conf
@@ -21,18 +21,34 @@ server {
             return 301 https://$host$request_uri;
         }
 
-        add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS';
-
-        # Custom headers and headers various browsers *should* be OK with but aren't
-        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
-
         if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS';
+            # Custom headers and headers various browsers *should* be OK with but aren't
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
             # Tell client that this pre-flight info is valid for 20 days
             add_header 'Access-Control-Max-Age' 1728000;
             add_header 'Content-Type' 'text/plain charset=UTF-8';
             add_header 'Content-Length' 0;
             return 204;
+        }
+
+        if ($request_method = 'POST') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
+        }
+
+        if ($request_method = 'PUT') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
+        }
+
+        if ($request_method = 'GET') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
         }
 
         set $awsilb "http://internal-cognoma-core-service-1847480158.us-east-1.elb.amazonaws.com";


### PR DESCRIPTION
This PR addresses three issues.

1. When accessing a user, you can use either the slug or the id of the
user. The problem is that using a regex to capture a slug may make it
impossible for you to just use the id, as it may be interpreted as a
slug. The solution is to separate the two methods of access by prepending
the url with `/slug/` or `/id/` depending on the method used. For example,
accessing by slug would look like
`api.cognoma.org/users/slugs/alsihfakwrtakjh` whereas accessing by id
would look like `api.cognoma.org/users/id/8`.

2. Accessing by slug would also fail ungracefully if a user with the
specified slug didn’t exist. This commit handles that error gracefully
by returning a JSON 404 response with the message "No user exists with
random slug of {slug}."

3. I was facing some issues while working on the frontend with CORS on PUT
requests, so I updated the nginx dev config to fix these errors.