### PR TITLE
add a new field for getting union of all results with mutations in genes

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -245,7 +245,6 @@ class MutationRetrieve(generics.RetrieveAPIView):
 # Samples
 
 # via https://github.com/carltongibson/django-filter/issues/137#issuecomment-38158832
-# Thanks, Rich!
 class ListFilter(django_filters.Filter):
     def filter(self, qs, value):
         value_list = value.split(u',')

--- a/api/views.py
+++ b/api/views.py
@@ -245,6 +245,7 @@ class MutationRetrieve(generics.RetrieveAPIView):
 # Samples
 
 # via https://github.com/carltongibson/django-filter/issues/137#issuecomment-38158832
+# Courtesy of @miserlou
 class ListFilter(django_filters.Filter):
     def filter(self, qs, value):
         value_list = value.split(u',')

--- a/api/views.py
+++ b/api/views.py
@@ -244,13 +244,21 @@ class MutationRetrieve(generics.RetrieveAPIView):
 
 # Samples
 
+# via https://github.com/carltongibson/django-filter/issues/137#issuecomment-38158832
+# Thanks, Rich!
+class ListFilter(django_filters.Filter):
+    def filter(self, qs, value):
+        value_list = value.split(u',')
+        return super(ListFilter, self).filter(qs, django_filters.fields.Lookup(value_list, 'in'))
+
 class SampleFilter(filters.FilterSet):
     age_diagnosed__gte = django_filters.IsoDateTimeFilter(name='age_diagnosed', lookup_expr='gte')
     age_diagnosed__lte = django_filters.IsoDateTimeFilter(name='age_diagnosed', lookup_expr='lte')
+    all_mutations = ListFilter(name='mutations__gene')
 
     class Meta:
         model = Sample
-        fields = ['sample_id', 'disease', 'gender', 'age_diagnosed', 'mutations__gene', 'mutations__gene__entrez_gene_id']
+        fields = ['sample_id', 'disease', 'gender', 'age_diagnosed', 'all_mutations', 'mutations__gene', 'mutations__gene__entrez_gene_id']
 
 class SampleList(generics.ListAPIView):
     queryset = Sample.objects.all()


### PR DESCRIPTION
### Motivation
Add a filter to get all diseases with mutations in _any_ of listed genes (basically gene X OR gene Y OR gene Z)

Closes https://github.com/cognoma/frontend/issues/142

### Functional Tests

#### Before:
`https://api.cognoma.org/samples?limit=1&disease=HNSC&mutations__gene=283337&mutations__gene=55920&mutations__gene=1728&mutations__gene=479` yields a count of 9

But adding another gene: 
`https://api.cognoma.org/samples?limit=1&disease=HNSC&mutations__gene=283337&mutations__gene=55920&mutations__gene=1728&mutations__gene=479&mutations__gene=477` yields a count of `8`

#### Now:
The first query yields a count of 13 while adding in `477` yields a count of 21. So, it's always increasing.
