### PR TITLE
Update readme to new account

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ aws ecr get-login --region us-east-1
 ```
 and then run the output of that command. It will look something like:
 ```sh
-docker login -u AWS -p <A_GIANT_HASH> -e none https://934349674827.dkr.ecr.us-east-1.amazonaws.com
+docker login -u AWS -p <A_GIANT_HASH> -e none https://589864003899.dkr.ecr.us-east-1.amazonaws.com
 ```
 
 ### Building, Tagging, and Pushing the Container
@@ -94,8 +94,8 @@ You will probably be deploying only the core-service unless you have modified
 Run these commands:
 ```
 docker build --tag cognoma-core-service .
-docker tag cognoma-core-service:latest 934349674827.dkr.ecr.us-east-1.amazonaws.com/cognoma-core-service:latest
-docker push 934349674827.dkr.ecr.us-east-1.amazonaws.com/cognoma-core-service:latest
+docker tag cognoma-core-service:latest 589864003899.dkr.ecr.us-east-1.amazonaws.com/cognoma-core-service:latest
+docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/cognoma-core-service:latest
 ```
 
 #### Nginx Container
@@ -103,8 +103,8 @@ docker push 934349674827.dkr.ecr.us-east-1.amazonaws.com/cognoma-core-service:la
 Run these commands:
 ```
 docker build --tag cognoma-nginx --file config/prod/Dockerfile_nginx .
-docker tag cognoma-nginx:latest 934349674827.dkr.ecr.us-east-1.amazonaws.com/cognoma-nginx:latest
-docker push 934349674827.dkr.ecr.us-east-1.amazonaws.com/cognoma-nginx:latest
+docker tag cognoma-nginx:latest 589864003899.dkr.ecr.us-east-1.amazonaws.com/cognoma-nginx:latest
+docker push 589864003899.dkr.ecr.us-east-1.amazonaws.com/cognoma-nginx:latest
 ```
 
 ### Restarting the ECS Task

--- a/config/prod/nginx.conf
+++ b/config/prod/nginx.conf
@@ -2,7 +2,9 @@ server {
     listen 80;
     server_name api.cognoma.org;
 
-    resolver 8.8.8.8 valid=10s;
+    # This DNS server actually resolves the internal load balancer
+    # hostname. Not sure why google and Amazon's DNS servers don't...
+    resolver 172.31.0.2 valid=10s;
     resolver_timeout 10s;
 
     location / {
@@ -51,7 +53,7 @@ server {
             add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
         }
 
-        set $awsilb "http://internal-cognoma-core-service-1847480158.us-east-1.elb.amazonaws.com";
+        set $awsilb "http://internal-cognoma-core-service-2067962211.us-east-1.elb.amazonaws.com";
         proxy_pass $awsilb;
         # Enables Swagger to use correct HTTPS URL when making requests
         proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
### Motivation

We've moved from the Greenelab AWS account to the AlexsLemonade AWS account. This necessitated a few changes.

### Implementation Notes

The only implementation change here is the IP resolver. I think it wasn't working with the Google one because we changed up DNS settings. At this point those changes have probably propagated but it's working as is so why fix it?

### Functional Tests

I've used this branch to deploy the core service and it's currently working in production. (I tested production prior to opening the PR because there's no other way to functionally test this change.)
