### PR TITLE
Add tests for multi-sample queries

### DIFF
--- a/api/test/test_sample.py
+++ b/api/test/test_sample.py
@@ -74,31 +74,32 @@ class SampleTests(APITestCase):
     def test_single_gene_query(self):
         client = APIClient()
 
-        get_response = client.get('/samples?disease=' + self.disease1.acronym +
-                                  '&mutations__gene=' +
-                                  str(self.gene2.entrez_gene_id))
+        get_response = client.get('/samples', {
+                                  'disease': self.disease1.acronym,
+                                  'any_mutations': str(self.gene2.entrez_gene_id),
+                                  })
 
         self.assertEqual(get_response.status_code, 200)
         self.assertEqual(len(get_response.data['results']), 1)
-        expected_samples = set([self.sample3.sample_id,])
-        returned_samples = set([x['sample_id'] for x in get_response.data['results']])
+        expected_samples = [self.sample3.sample_id,]
+        returned_samples = [x['sample_id'] for x in get_response.data['results']]
         self.assertEqual(expected_samples, returned_samples)
 
     def test_multi_gene_query_order_invariant(self):
         client = APIClient()
 
-        get_response1 = client.get('/samples?disease=' + self.disease1.acronym +
-                                  '&any_mutations=' +
-                                  str(self.gene2.entrez_gene_id) +
-                                  ',' +
-                                  str(self.gene1.entrez_gene_id))
+        get_response1 = client.get('/samples', {
+                                  'disease': self.disease1.acronym,
+                                  'any_mutations':
+                                      ','.join([str(self.gene1.entrez_gene_id), str(self.gene2.entrez_gene_id)]),
+                                  })
         self.assertEqual(get_response1.status_code, 200)
 
-        get_response2 = client.get('/samples?disease=' + self.disease1.acronym +
-                                  '&any_mutations=' +
-                                  str(self.gene1.entrez_gene_id) +
-                                  ',' +
-                                  str(self.gene2.entrez_gene_id))
+        get_response2 = client.get('/samples', {
+                                  'disease': self.disease1.acronym,
+                                  'any_mutations':
+                                      ','.join([str(self.gene2.entrez_gene_id), str(self.gene1.entrez_gene_id)]),
+                                  })
         self.assertEqual(get_response2.status_code, 200)
 
         self.assertEqual(get_response1.data['results'], get_response2.data['results'])
@@ -106,15 +107,15 @@ class SampleTests(APITestCase):
     def test_multi_gene_query(self):
         client = APIClient()
 
-        get_response = client.get('/samples?disease=' + self.disease1.acronym +
-                                  '&any_mutations=' +
-                                  str(self.gene2.entrez_gene_id) +
-                                  ',' +
-                                  str(self.gene1.entrez_gene_id))
+        get_response = client.get('/samples', {
+                                  'disease': self.disease1.acronym,
+                                  'any_mutations':
+                                      ','.join([str(self.gene2.entrez_gene_id), str(self.gene1.entrez_gene_id)]),
+                                  })
 
         self.assertEqual(get_response.status_code, 200)
         self.assertEqual(len(get_response.data['results']), 3)
-        expected_samples = set([self.sample1.sample_id, self.sample2.sample_id,
-            self.sample3.sample_id,])
-        returned_samples = set([x['sample_id'] for x in get_response.data['results']])
-        self.assertEqual(expected_samples, returned_samples)
+        expected_samples = [self.sample1.sample_id, self.sample2.sample_id,
+            self.sample3.sample_id,]
+        returned_samples = [x['sample_id'] for x in get_response.data['results']]
+        self.assertEqual(sorted(expected_samples), sorted(returned_samples))

--- a/api/test/test_sample.py
+++ b/api/test/test_sample.py
@@ -38,6 +38,10 @@ class SampleTests(APITestCase):
                                              disease=self.disease1,
                                              gender='male',
                                              age_diagnosed=43)
+        self.sample4 = Sample.objects.create(sample_id='TCGA-2G-AALW-03',
+                                             disease=self.disease1,
+                                             gender='male',
+                                             age_diagnosed=42)
         self.mutation1 = Mutation.objects.create(gene=self.gene1,
                                                  sample=self.sample1)
         self.mutation2 = Mutation.objects.create(gene=self.gene1,
@@ -55,7 +59,7 @@ class SampleTests(APITestCase):
                                                            'next',
                                                            'previous',
                                                            'results'])
-        self.assertEqual(len(list_response.data['results']), 3)
+        self.assertEqual(len(list_response.data['results']), 4)
         self.assertEqual(list(list_response.data['results'][0].keys()), self.sample_keys)
         self.assertEqual(list(list_response.data['results'][1].keys()), self.sample_keys)
 
@@ -84,16 +88,16 @@ class SampleTests(APITestCase):
         client = APIClient()
 
         get_response1 = client.get('/samples?disease=' + self.disease1.acronym +
-                                  '&mutations__gene=' +
+                                  '&any_mutations=' +
                                   str(self.gene2.entrez_gene_id) +
-                                  '&mutations__gene=' +
+                                  ',' +
                                   str(self.gene1.entrez_gene_id))
         self.assertEqual(get_response1.status_code, 200)
 
         get_response2 = client.get('/samples?disease=' + self.disease1.acronym +
-                                  '&mutations__gene=' +
+                                  '&any_mutations=' +
                                   str(self.gene1.entrez_gene_id) +
-                                  '&mutations__gene=' +
+                                  ',' +
                                   str(self.gene2.entrez_gene_id))
         self.assertEqual(get_response2.status_code, 200)
 
@@ -103,9 +107,9 @@ class SampleTests(APITestCase):
         client = APIClient()
 
         get_response = client.get('/samples?disease=' + self.disease1.acronym +
-                                  '&mutations__gene=' +
+                                  '&any_mutations=' +
                                   str(self.gene2.entrez_gene_id) +
-                                  '&mutations__gene=' +
+                                  ',' +
                                   str(self.gene1.entrez_gene_id))
 
         self.assertEqual(get_response.status_code, 200)

--- a/api/test/test_sample.py
+++ b/api/test/test_sample.py
@@ -17,6 +17,13 @@ class SampleTests(APITestCase):
                                          gene_type='bar',
                                          synonyms=['foo', 'bar'],
                                          aliases=['foo', 'bar'])
+        self.gene2 = Gene.objects.create(entrez_gene_id=123457,
+                                         symbol='GENE1234',
+                                         description='fooo',
+                                         chromosome='12',
+                                         gene_type='barr',
+                                         synonyms=['fooo', 'barr'],
+                                         aliases=['fooo', 'barr'])
         self.disease1 = Disease.objects.create(acronym='BLCA',
                                                name='bladder urothelial carcinoma')
         self.sample1 = Sample.objects.create(sample_id='TCGA-22-4593-01',
@@ -27,11 +34,16 @@ class SampleTests(APITestCase):
                                              disease=self.disease1,
                                              gender='male',
                                              age_diagnosed=43)
-
+        self.sample3 = Sample.objects.create(sample_id='TCGA-2G-AALW-02',
+                                             disease=self.disease1,
+                                             gender='male',
+                                             age_diagnosed=43)
         self.mutation1 = Mutation.objects.create(gene=self.gene1,
                                                  sample=self.sample1)
         self.mutation2 = Mutation.objects.create(gene=self.gene1,
                                                  sample=self.sample2)
+        self.mutation3 = Mutation.objects.create(gene=self.gene2,
+                                                 sample=self.sample3)
 
     def test_list_samples(self):
         client = APIClient()
@@ -43,7 +55,7 @@ class SampleTests(APITestCase):
                                                            'next',
                                                            'previous',
                                                            'results'])
-        self.assertEqual(len(list_response.data['results']), 2)
+        self.assertEqual(len(list_response.data['results']), 3)
         self.assertEqual(list(list_response.data['results'][0].keys()), self.sample_keys)
         self.assertEqual(list(list_response.data['results'][1].keys()), self.sample_keys)
 
@@ -54,3 +66,51 @@ class SampleTests(APITestCase):
 
         self.assertEqual(get_response.status_code, 200)
         self.assertEqual(list(get_response.data.keys()), self.sample_keys)
+
+    def test_single_gene_query(self):
+        client = APIClient()
+
+        get_response = client.get('/samples?disease=' + self.disease1.acronym +
+                                  '&mutations__gene=' +
+                                  str(self.gene2.entrez_gene_id))
+
+        self.assertEqual(get_response.status_code, 200)
+        self.assertEqual(len(get_response.data['results']), 1)
+        expected_samples = set([self.sample3.sample_id,])
+        returned_samples = set([x['sample_id'] for x in get_response.data['results']])
+        self.assertEqual(expected_samples, returned_samples)
+
+    def test_multi_gene_query_order_invariant(self):
+        client = APIClient()
+
+        get_response1 = client.get('/samples?disease=' + self.disease1.acronym +
+                                  '&mutations__gene=' +
+                                  str(self.gene2.entrez_gene_id) +
+                                  '&mutations__gene=' +
+                                  str(self.gene1.entrez_gene_id))
+        self.assertEqual(get_response1.status_code, 200)
+
+        get_response2 = client.get('/samples?disease=' + self.disease1.acronym +
+                                  '&mutations__gene=' +
+                                  str(self.gene1.entrez_gene_id) +
+                                  '&mutations__gene=' +
+                                  str(self.gene2.entrez_gene_id))
+        self.assertEqual(get_response2.status_code, 200)
+
+        self.assertEqual(get_response1.data['results'], get_response2.data['results'])
+
+    def test_multi_gene_query(self):
+        client = APIClient()
+
+        get_response = client.get('/samples?disease=' + self.disease1.acronym +
+                                  '&mutations__gene=' +
+                                  str(self.gene2.entrez_gene_id) +
+                                  '&mutations__gene=' +
+                                  str(self.gene1.entrez_gene_id))
+
+        self.assertEqual(get_response.status_code, 200)
+        self.assertEqual(len(get_response.data['results']), 3)
+        expected_samples = set([self.sample1.sample_id, self.sample2.sample_id,
+            self.sample3.sample_id,])
+        returned_samples = set([x['sample_id'] for x in get_response.data['results']])
+        self.assertEqual(expected_samples, returned_samples)

--- a/api/views.py
+++ b/api/views.py
@@ -277,11 +277,11 @@ class ListFilter(django_filters.Filter):
 class SampleFilter(filters.FilterSet):
     age_diagnosed__gte = django_filters.IsoDateTimeFilter(name='age_diagnosed', lookup_expr='gte')
     age_diagnosed__lte = django_filters.IsoDateTimeFilter(name='age_diagnosed', lookup_expr='lte')
-    all_mutations = ListFilter(name='mutations__gene')
+    any_mutations = ListFilter(name='mutations__gene')  # Return union
 
     class Meta:
         model = Sample
-        fields = ['sample_id', 'disease', 'gender', 'age_diagnosed', 'all_mutations', 'mutations__gene', 'mutations__gene__entrez_gene_id']
+        fields = ['sample_id', 'disease', 'gender', 'age_diagnosed', 'any_mutations', 'mutations__gene', 'mutations__gene__entrez_gene_id']
 
 class SampleList(generics.ListAPIView):
     queryset = Sample.objects.all()


### PR DESCRIPTION
### Motivation

Issue #95 reports that the correct sample counts are not returned for multi-gene queries. This provides additional tests that cover the bug. 

### API changes

As part of fixing this, it made sense to convert `all_mutations` to `any_mutations` as it returns the samples with mutations in any of the genes.

### Implementation Notes

We add an additional gene so that we can do multi-gene tests, and we add a third and fourth sample. The list test is updated for the additional sample number. I also added a single gene query test. For multi-gene queries, we test that the same results are returned regardless of order (not true now) and that the right results are returned for a specific query.

### Functional Tests

* Single gene query.
* Multi-gene query (see that results are the same regardless of order).
* Multi-gene query (see that the expected samples are returned).

### Screenshots/Logs

![screen shot 2018-03-30 at 2 41 15 pm](https://user-images.githubusercontent.com/542643/38149429-73ac0378-3428-11e8-85a2-12d1d03284e6.png)

---

After revisions, new tests pass:
![screen shot 2018-03-30 at 4 01 03 pm](https://user-images.githubusercontent.com/542643/38152009-94fa7f36-3433-11e8-962a-ef568d3f7797.png)
